### PR TITLE
Location argument for Alice's DAC class + rectangular filter length issue

### DIFF
--- a/docs/source/understanding/configuration.md
+++ b/docs/source/understanding/configuration.md
@@ -940,7 +940,7 @@ Those filters are mainly used to filter the tones.
 Cut-off frequency for the filtering of the pilots in Hz.
 
 ````{note}
-Once the pilot as been detected by a maximum peak searching in frequency, yielding the frequency {math}`f_{tone}`, the tone is filtered with a FIR filter on the frequency region
+Once the pilot has been detected by a maximum peak searching in frequency, yielding the frequency {math}`f_{tone}`, the tone is filtered with a FIR filter on the frequency region
 
 ```{math}
 \left[f_{tone} - f_{cutoff}, f_{tone}+f_{cutoff}\right]
@@ -948,6 +948,13 @@ Once the pilot as been detected by a maximum peak searching in frequency, yieldi
 
 ````
 `````
+
+```{py:attribute} direct_pilot_tracking
+:type: bool
+:value: False
+
+If `True`, a simpler and significantly faster algorithm is used for demodulation. The first pilot tone is recovered in the time-domain with a band-pass filter, its phase is smoothed, and the resulting signal is used to frequency-shift the quantum data back to the baseband. No explicit frequency estimation of the pilot is performed.
+```
 
 ```{py:attribute} process_subframes
 :type: bool
@@ -970,6 +977,41 @@ This parameter controls if the data should be processed as subframes (`True`) or
 The size of the subframes can be adjusted by choosing how many **symbols** should be recovered in each subframes.
 
 This parameter should not be 0 if `process_subframes` is `True`.
+```
+
+```{py:attribute} subframes_subdivisions
+:type: int
+:value: 1
+
+During the global phase recovery step, a subframe can be further divided into smaller chunks, each of which will then receive a different phase correction. This makes the detection more capable of tracking sudden phase shifts, but with the risk of inducing more noise due to phase estimation errors.
+```
+
+```{py:attribute} num_samples_pilot_search
+:type: int
+:value: 10000000
+
+Number of samples to use for pilot frequency estimation. Due to the limited frequency resolution of the FFT, a large sample size above 1M is needed to resolve small ADC/DAC clock errors.
+```
+
+```{py:attribute} symbol_timing_oversampling
+:type: int
+:value: 1
+
+The factor by which the signal is oversampled when determining the optimal symbol timing grid.
+```
+
+```{py:attribute} elec_noise_estimation_ratio
+:type: float
+:value: 0.1
+
+Proportion of samples to keep for the electronic noise estimation. For example, a value of 0.1 means that the noise will be estimated on the last 10% of the signal duration. Since the electronic noise sample is fairly long, performing the estimation on a subset of the data will still provide reliable estimates.
+```
+
+```{py:attribute} elec_shot_noise_estimation_ratio
+:type: float
+:value: 1.0
+
+Proportion of samples to keep for the electronic+shot noise estimation. For example, 0.1 means the noise will be estimated on the last 10% of the signal duration. The electronic+shot noise signal is typically short and can be analyzed in its entirety without a significant computational cost.
 ```
 
 ```{py:attribute} abort_clock_recovery

--- a/qosst_core/comm/filters.py
+++ b/qosst_core/comm/filters.py
@@ -155,10 +155,8 @@ def rect_filter(length: int, symbol_period: float, sampling_rate: float):
     coeffs = np.ones(length)
     time_delta = 1 / float(sampling_rate)
     time_idx = ((np.arange(length) - length / 2)) * time_delta
-
-    coeffs[time_idx < -symbol_period / 2] = 0
+    coeffs[time_idx <= -symbol_period / 2] = 0
     coeffs[time_idx > symbol_period / 2] = 0
-
     return time_idx, coeffs
 
 
@@ -169,7 +167,7 @@ class Filter(abc.ABC):
     A filter has a times and filter attributes that are initialized by the
     __init__ and set_filter abstract methods.
 
-    There is a also a mehtod apply filter to directly apply the current filter.
+    The apply method directly applies the current filter to data.
     """
 
     times: np.ndarray  #: time array.
@@ -204,7 +202,7 @@ class Filter(abc.ABC):
         return self.times
 
     def apply_filter(self, data: np.ndarray) -> np.ndarray:
-        """Apply the filter to data and returns the filtered data.
+        """Applies the filter to data and returns the filtered data.
 
         This methods uses the fftconvolve from scipy to apply the filter.
 

--- a/qosst_core/configuration/alice.py
+++ b/qosst_core/configuration/alice.py
@@ -144,12 +144,14 @@ class AliceDACConfiguration(BaseConfiguration):
     Class holding the configuration for Alice DAC. It should be initialized with the alice.dac section.
     """
 
+    location: str  #: Location of the DAC
     rate: float  #: Rate of the DAC, in Samples/second.
     amplitude: float  #: Amplitude of the DAC, in V.
     device: Type[GenericDAC]  #: Device class of the DAC.
     channels: list  #: List of channels to use.
     extra_args: dict  #: Extra args to pass to the DAC class.
 
+    DEFAULT_LOCATION: str = ""  #: Default location
     DEFAULT_RATE: float = 500e6  #: Default rate in Samples/second.
     DEFAULT_AMPLITUDE: float = 0  #: Default amplitude, in V.
     DEFAULT_DEVICE_STR: str = "qosst_hal.dac.FakeDAC"  #: Default class of the DAC.
@@ -166,6 +168,7 @@ class AliceDACConfiguration(BaseConfiguration):
             InvalidConfiguration: if the dac class cannot be loaded.
             InvalidConfiguration: if the dac device is not a subclass of GenericDAC
         """
+        self.location = config.get("location", self.DEFAULT_LOCATION)
         self.rate = config.get("rate", self.DEFAULT_RATE)
         self.amplitude = config.get("amplitude", self.DEFAULT_AMPLITUDE)
         device_str = config.get("device", self.DEFAULT_DEVICE_STR)
@@ -185,6 +188,7 @@ class AliceDACConfiguration(BaseConfiguration):
     def __str__(self) -> str:
         res = "Alice DAC Configuration\n"
         res += "-----------------------\n"
+        res += f"Location : {self.location}\n"
         res += f"Rate : {self.rate*1e-6} MSamples/s\n"
         res += f"Amplitude : {self.amplitude}\n"
         res += f"Device : {self.device}\n"

--- a/qosst_core/configuration/bob.py
+++ b/qosst_core/configuration/bob.py
@@ -442,6 +442,8 @@ class BobDSPConfiguration(BaseConfiguration):
     equalizer: (
         BobDSPEqualizerConfiguration  #: The equalizer part of Bob's DSP configuration
     )
+    elec_noise_estimation_ratio: float  #: Ratio of the total number of electronic noise samples to use for the variance estimation
+    elec_shot_noise_estimation_ratio: float  #: Ratio of the total number of electronic and shot noise samples to use for the variance estimation
 
     DEFAULT_DEBUG: bool = True  #: Default value fot the debug mode.
     DEFAULT_FIR_SIZE: int = 500
@@ -459,6 +461,8 @@ class BobDSPConfiguration(BaseConfiguration):
         0  #: Default value for the filtering size of the phase for the phase recovery.
     )
     DEFAULT_NUM_SAMPLES_FBEAT_ESTIMATION: int = 100000
+    DEFAULT_ELEC_NOISE_ESTIMATION_RATIO: float = 1.0
+    DEFAULT_ELEC_SHOT_NOISE_ESTIMATION_RATIO: float = 1.0
 
     def from_dict(self, config: dict) -> None:
         """Read configuration from dict.
@@ -495,6 +499,12 @@ class BobDSPConfiguration(BaseConfiguration):
             "num_samples_fbeat_estimation", self.DEFAULT_NUM_SAMPLES_FBEAT_ESTIMATION
         )
         self.equalizer = BobDSPEqualizerConfiguration(config.get("equalizer", {}))
+        self.elec_noise_estimation_ratio = config.get(
+            "elec_noise_estimation_ratio", self.DEFAULT_ELEC_NOISE_ESTIMATION_RATIO
+        )
+        self.elec_shot_noise_estimation_ratio = config.get(
+            "elec_shot_noise_estimation_ratio", self.DEFAULT_ELEC_SHOT_NOISE_ESTIMATION_RATIO
+        )
 
     def __str__(self) -> str:
         res = "Bob DSP Configuration\n"
@@ -508,7 +518,9 @@ class BobDSPConfiguration(BaseConfiguration):
         res += f"Alice DAC rate : {self.alice_dac_rate}\n"
         res += f"Exclusion zone : {self.exclusion_zone_pilots}\n"
         res += f"Pilot phase filtering size : {self.pilot_phase_filtering_size}\n"
-        res += f"Number of samples for fbeat estimation : {self.DEFAULT_NUM_SAMPLES_FBEAT_ESTIMATION}\n"
+        res += f"Number of samples for fbeat estimation : {self.num_samples_fbeat_estimation}\n"
+        res += f"Ratio of number of samples for electronic noise estimation : {self.elec_noise_estimation_ratio}\n"
+        res += f"Ratio of number of samples for electronic and shot noise estimation : {self.elec_shot_noise_estimation_ratio}\n"
         res += "\n"
         res += str(self.equalizer)
         return res

--- a/qosst_core/configuration/config.example.toml
+++ b/qosst_core/configuration/config.example.toml
@@ -214,6 +214,10 @@ bind_port = 8181
 # Default : 500e6
 rate = 500e6
 
+# Location of the device
+# Default : ""
+location = ""
+
 # Amplitude, in V
 # The generated data by the DSP will be between +1 and -1
 # If the amplitude is A, then this means that the +1 will be

--- a/qosst_core/configuration/config.example.toml
+++ b/qosst_core/configuration/config.example.toml
@@ -507,6 +507,12 @@ timeout = 10
 
 [bob.dsp]
 
+# Direct pilot tracking.
+# If True, the first pilot can directly be used to estimate beat frequency
+# and phase noise
+# Default : false
+direct_pilot_tracking = false
+
 # Debug mode.
 # If True, a DSPDebug object is returned with additional information.
 # Default : true
@@ -523,12 +529,15 @@ fir_size = 500
 tone_filtering_cutoff = 10e6
 
 # Set true to process the data in subframes
-# Default : false
-process_subframes = false
+# Default : true
+process_subframes = true
 
 # Size of the subframes if process_subframes is true
-# Default : 0
-subframes_size = 0
+# Default : 50000
+subframes_size = 50000
+
+# Number of a subdivisions of a subframe
+subframes_subdivisions = 4
 
 # Abort clock recovery
 # If the difference of clock mismatch (in ratio)
@@ -550,22 +559,40 @@ alice_dac_rate = 500e6
 # Default: [[0.0, 100e3]]
 exclusion_zone_pilots = [[0.0, 100e3]]
 
-# Size of filter for the phase recovery
-# If not 0, the recovered phase will be filter with
+# Size of phase filter for the phase recovery
+# If not 0, the recovered phase noise will be filtered with
 # a uniform1d filter (i.e. moving average) with the size
 # defined by this parameter.
 # Default: 0
 pilot_phase_filtering_size = 0
+
+# Size of derivative of phase filter for the phase recovery
+# If not 0, the recovered derivative of the phase noise will be filtered with
+# a uniform1d filter (i.e. moving average) with the size
+# defined by this parameter.
+# Default: 0
+pilot_frequency_filtering_size = 0
 
 # Number of samples to estimate properly
 # f_beat in general dsp
 # Default : 100000
 num_samples_fbeat_estimation = 100000
 
+# Number of samples to estimate the frequency of the pilots
+# Default : 10 000 000
+num_samples_pilot_search = 10000000
+
+# By which factor the signal is oversampled when searching for the
+# optimal symbol sampling time.
+# Default : 1
+symbol_timing_oversampling = 1
+
 # Proportion of samples to keep for the electronic noise estimation.
+# Default : 0.1 (10% of all samples)
 elec_noise_estimation_ratio = 0.1
 
 # Proportion of samples to keep for the electronic+shot noise estimation.
+# Default : 1.0 (all samples)
 elec_shot_noise_estimation_ratio = 1.0
 
 [bob.dsp.equalizer]

--- a/qosst_core/configuration/config.example.toml
+++ b/qosst_core/configuration/config.example.toml
@@ -562,6 +562,12 @@ pilot_phase_filtering_size = 0
 # Default : 100000
 num_samples_fbeat_estimation = 100000
 
+# Proportion of samples to keep for the electronic noise estimation.
+elec_noise_estimation_ratio = 0.1
+
+# Proportion of samples to keep for the electronic+shot noise estimation.
+elec_shot_noise_estimation_ratio = 1.0
+
 [bob.dsp.equalizer]
 
 # If true, use the CMA equalizer.


### PR DESCRIPTION
The addition of the ```location``` parameter for Alice's DAC ensures consistency with all other similar classes (VOA, ADC...).

---

Rectangular filter: the code resulted in a filter response with an extra non-zero sample, causing some overlaps between consecutive symbols.

To reproduce:

```
import matplotlib.pyplot as plt
import numpy as np

from qosst_core.modulation import PSKModulation
from qosst_alice.dsp import generate_baseband_sequence, upsample, apply_rectangular_filter

data = generate_baseband_sequence(
    modulation_cls=PSKModulation,
    variance=1,
    modulation_size=4,
    num_symbols=50,
)

symbol_rate = 100e6
dac_rate = 2000e6
sps = int(dac_rate / symbol_rate)

data = upsample(sequence=data, upsample_ratio=sps)

roll_off = 1.0

data = apply_rectangular_filter(
    data,
    10 * sps + 2,
    roll_off,
    1 / symbol_rate,
    dac_rate,
)

fig, axs = plt.subplots(2, 2)
gs = axs[0, 1].get_gridspec()
for ax in axs[0:, -1]:
    ax.remove()
ax3 = fig.add_subplot(gs[0:, -1])
(ax, _), (ax2, _) = axs
times = np.arange(len(data)) / dac_rate
ax.plot(times, data.real, color="black")
ax2.plot(times, data.imag, color="black")
ax3.scatter(data.real, data.imag, color="black")
ax3.set_aspect("equal")
ax.grid()
ax2.grid()
ax3.grid()
ax.set_xlabel("Time [s]")
ax2.set_xlabel("Time [s]")
ax.set_ylabel("Real part")
ax2.set_ylabel("Imag part")
ax3.set_xlabel("Real part")
ax3.set_ylabel("Imag part")
fig.tight_layout()
```

Before:

![rectangular_filter_bug_before](https://github.com/user-attachments/assets/1b56c89f-0229-4782-9e1e-d034b74ca807)

After:

![rectangular_filter_bug_after](https://github.com/user-attachments/assets/7e1b1acc-f025-48f2-8969-141a1cc3764d)