### PR TITLE
Add amplitude parameter for the Zadoff-Chu

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@ sys.path.insert(0, os.path.abspath("."))
 # -- Project information -----------------------------------------------------
 
 project = "qosst-core"
-copyright = "2021-2024, Yoann Piétri, Ilektra Karakosta-Amarantidou"
-author = "Yoann Piétri, Ilektra Karakosta-Amarantidou"
+copyright = "2021-2024, Yoann Piétri, Ilektra Karakosta-Amarantidou, Matteo Schiavon"
+author = "Yoann Piétri, Ilektra Karakosta-Amarantidou, Matteo Schiavon"
 
 # The full version, including alpha/beta/rc tags
 release = __version__

--- a/docs/source/understanding/configuration.md
+++ b/docs/source/understanding/configuration.md
@@ -1337,6 +1337,16 @@ Rate of the Zadoff-Chu sequence in Samples/second. The notation e is available.
 If 0 is used, the Zadoff-Chu is emitted at the maximal rate (*i.e.* the rate of Alice's DAC).
 ```
 
+```{py:attribute} amplitude
+:type: float
+:value: 1
+:noindex:
+
+Relative amplitude of the Zadoff-Chu sequence. 
+
+An amplitude of 0 means that there is no Zadoff-Chu at the beginning of the frame. An amplitude of 1 means that the Zadoff-Chu is emitted at the maximum voltage of the DAC.
+
+
 ## Example configuration file
 
 Below is displayed the example configuration file as provided in the `qosst-core` package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Core submodule of QOSST, containing modules for configuration, co
 authors = [
   "Yoann Piétri <Yoann.Pietri@lip6.fr>",
   "Ilektra Karakosta-Amarantidou <ilektra.karakostaamarantidou@studenti.unipd.it>",
+  "Matteo Schiavon <Matteo.Schiavon@lip6.fr>",
 ]
 include = ["qosst_core/configuration/config.example.toml"]
 packages = [{ include = "qosst_core" }, { include = "qosst_core/py.typed" }]

--- a/qosst_core/configuration/config.example.toml
+++ b/qosst_core/configuration/config.example.toml
@@ -737,3 +737,8 @@ length = 3989
 # A rate of 0 will be understood as to use the same rate as the DAC.
 # Default : 0
 rate = 0
+
+# The amplitude of the Zadoff-Chu sequence.
+# An amplitude of 1 means that the Zadoff-Chu is output at the maximum amplitude of the DAC.
+# Default : 1
+amplitude = 1

--- a/qosst_core/configuration/frame.py
+++ b/qosst_core/configuration/frame.py
@@ -170,10 +170,12 @@ class FrameZadoffChuConfiguration(BaseConfiguration):
     root: int  #: Root value for the Zadoff-Chu Sequence
     length: int  #: Length of the Zadoff-Chu sequence
     rate: float  #: Rate of the Zadoff-Chu sequence. A rate of zero will be understood as the same rate as the DAC.
+    amplitude: float  #: Amplitude of the Zadoff-Chu sequence. An amplitude of 1.0 means that the sequence is output at the maximum amplitude of the DAC.
 
     DEFAULT_ROOT: int = 5  #: Default value for the root.
     DEFAULT_LENGTH: int = 3989  #: Default value for the length.
     DEFAULT_RATE: float = 0  #: Default rate.
+    DEFAULT_AMPLITUDE: float = 1  #: Default amplitude of the Zadoff-Chu sequence.
 
     def from_dict(self, config: dict) -> None:
         """Fill instance from dict.
@@ -187,6 +189,7 @@ class FrameZadoffChuConfiguration(BaseConfiguration):
         self.root = config.get("root", self.DEFAULT_ROOT)
         self.length = config.get("length", self.DEFAULT_LENGTH)
         self.rate = config.get("rate", self.DEFAULT_RATE)
+        self.amplitude = config.get("amplitude", self.DEFAULT_AMPLITUDE)
 
         if not gcd(self.root, self.length) == 1:
             raise InvalidConfiguration(
@@ -199,6 +202,7 @@ class FrameZadoffChuConfiguration(BaseConfiguration):
         res += f"Root : {self.root}\n"
         res += f"Length : {self.length}\n"
         res += f"Rate : {self.rate}\n"
+        res += f"Amplitude: {self.amplitude}\n"
         return res
 
 


### PR DESCRIPTION
Add a new parameter in the Zadoff-Chu section of the configuration allowing to choose the amplitude of the Zadoff-Chu.